### PR TITLE
added ORDER BY to MySQL views

### DIFF
--- a/SQL/iredmail+alias.my.sql
+++ b/SQL/iredmail+alias.my.sql
@@ -15,4 +15,5 @@ VIEW `MultiBook` AS
                     AND (`vmail`.`alias`.`address` LIKE '%@%'))) AS `email`,
         `vmail`.`mailbox`.`domain` AS `domain`
     FROM
-        `vmail`.`mailbox`;
+        `vmail`.`mailbox`
+    ORDER BY name;

--- a/SQL/iredmail.my.sql
+++ b/SQL/iredmail.my.sql
@@ -10,4 +10,5 @@ VIEW `MultiBook` AS
         `vmail`.`mailbox`.`username` AS `email`,
         `vmail`.`mailbox`.`domain` AS `domain`
     FROM
-        `vmail`.`mailbox`;
+        `vmail`.`mailbox`
+    ORDER BY name;


### PR DESCRIPTION
As in RC there's no option for sorting, I've added `ORDER BY name` (the most natural, and what's used for display) to the MySQL view examples. Skipped the PostgreSQL example as I cannot verify that (seems to use a slightly different/specific syntax).
